### PR TITLE
Update courier dependency to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project attempts to follow [Semantic Versioning](http://semver.org/spec
 
 ## Unreleased
 
+### Removed
+
+* Dropped support for Courier 0.4 and 0.5
+
+### Changed
+
+* Added support for Courier 0.6
+
 ## 0.1.1
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "mailjet/mailjet-apiv3-php": "^1.4.1",
         "guzzlehttp/guzzle": "^6.3",
-        "quartzy/courier": "^0.4.0|^0.5.0",
+        "quartzy/courier": "^0.6",
         "ramsey/uuid": "^3.0"
     },
     "require-dev": {

--- a/src/MailjetCourier.php
+++ b/src/MailjetCourier.php
@@ -15,7 +15,6 @@ use PhpEmail\Attachment;
 use PhpEmail\Content;
 use PhpEmail\Content\Contracts\SimpleContent;
 use PhpEmail\Content\Contracts\TemplatedContent;
-use PhpEmail\Content\EmptyContent;
 use PhpEmail\Email;
 use PhpEmail\Header;
 use Ramsey\Uuid\Uuid;
@@ -64,7 +63,6 @@ class MailjetCourier implements ConfirmingCourier
     protected function supportedContent(): array
     {
         return [
-            EmptyContent::class,
             SimpleContent::class,
             TemplatedContent::class,
         ];
@@ -91,7 +89,7 @@ class MailjetCourier implements ConfirmingCourier
                     'To' => $this->buildAddresses($email->getToRecipients()),
                     'Cc' => $this->buildAddresses($email->getCcRecipients()),
                     'Bcc' => $this->buildAddresses($email->getBccRecipients()),
-                    'Subject' => substr($email->getSubject(), 0, 255),
+                    'Subject' => $email->getSubject() !== null ? substr($email->getSubject(), 0, 255) : '',
                     'Attachments' => $this->buildAttachments($email->getAttachments(), false),
                     'InlinedAttachments' => $this->buildAttachments($email->getEmbedded(), true),
                 ], $this->buildContent($email)),


### PR DESCRIPTION
This update requires removing references to the EmptyContent type as well
as ensuring the courier can deliver a templated email with a null subject.
Because MailJet does not support using template variables in the subject,
the courier will send an empty string when it is null to avoid validation
errors, and the subject on the template will still be used.